### PR TITLE
🎨 feat: プロフィールページの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.3",
     "class-variance-authority": "^0.7.1",
     "firebase": "^11.4.0",
     "firebase-admin": "^13.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.3
+        version: 1.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1502,6 +1505,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.2':
+    resolution: {integrity: sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.1':
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
@@ -1531,6 +1547,15 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.0':
+    resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.5':
@@ -1629,6 +1654,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.2':
+    resolution: {integrity: sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.1.2':
     resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
@@ -1636,6 +1674,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.3':
+    resolution: {integrity: sha512-9mFyI30cuRDImbmFF6O2KUJdgEOsGh9Vmx9x/Dh9tOhL7BngmQPQfwW4aejKm5OHpfWIdmeV6ySyuxoOGjtNng==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.0':
@@ -7010,6 +7061,18 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
+  '@radix-ui/react-collection@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
   '@radix-ui/react-compose-refs@1.1.1(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       react: 19.0.0
@@ -7043,6 +7106,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
+  '@radix-ui/react-direction@1.1.0(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
 
   '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -7119,12 +7188,45 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
+  '@radix-ui/react-roving-focus@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
   '@radix-ui/react-slot@1.1.2(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.10
+
+  '@radix-ui/react-tabs@1.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.0.10)(react@19.0.0)':
     dependencies:

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -1,0 +1,5 @@
+import { ProfilePage } from '@/components/pages/profilePage';
+
+export default function Page() {
+  return <ProfilePage />;
+}

--- a/src/components/features/profile/emojiGrid.tsx
+++ b/src/components/features/profile/emojiGrid.tsx
@@ -1,0 +1,35 @@
+import type { EmojiProps } from '@/components/features/profile/types';
+import Image from 'next/image';
+
+interface EmojiGridProps {
+  emojis: EmojiProps[];
+}
+
+export const EmojiGrid = ({ emojis }: EmojiGridProps) => {
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {emojis.map((emoji) => (
+        <div
+          key={emoji.id}
+          className="relative aspect-square bg-white rounded-lg p-2"
+        >
+          <div className="w-full h-full bg-red-500 relative">
+            {/* 花の茎 */}
+            <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-4 h-8 bg-green-500" />
+            {/* クリエイターアイコン */}
+            <div className="absolute -bottom-2 -left-2 w-6 h-6 rounded-full overflow-hidden border-2 border-white">
+              <div className="relative w-full h-full">
+                <Image
+                  src={emoji.creator.avatar || '/placeholder.svg'}
+                  alt="Creator"
+                  fill
+                  className="object-cover"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/features/profile/profileHeader.tsx
+++ b/src/components/features/profile/profileHeader.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { MoreVertical } from 'lucide-react';
+import Link from 'next/link';
+
+export const ProfileHeader = () => {
+  return (
+    <div className="flex items-center justify-between p-4 border-b">
+      <Link href="/chat" className="text-2xl">
+        👈
+      </Link>
+      <div className="w-6" /> {/* スペーサー */}
+      <button type="button" className="text-black">
+        <MoreVertical className="w-6 h-6" />
+      </button>
+    </div>
+  );
+};

--- a/src/components/features/profile/profileTabs.tsx
+++ b/src/components/features/profile/profileTabs.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { EmojiProps } from '@/components/features/profile/types';
+import { cn } from '@/lib/utils';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import * as React from 'react';
+import { EmojiGrid } from './emojiGrid';
+
+interface ProfileTabsProps {
+  createdEmojis: EmojiProps[];
+  collectedEmojis: EmojiProps[];
+}
+
+export const ProfileTabs = ({
+  createdEmojis,
+  collectedEmojis,
+}: ProfileTabsProps) => {
+  const [activeTab, setActiveTab] = React.useState('created');
+
+  return (
+    <TabsPrimitive.Root
+      defaultValue="created"
+      value={activeTab}
+      onValueChange={setActiveTab}
+      className="w-full"
+    >
+      <div className="border-b">
+        <TabsPrimitive.List className="flex w-full h-auto p-0 bg-transparent">
+          <TabsPrimitive.Trigger
+            value="created"
+            className={cn(
+              'flex-1 py-3 rounded-none border-b-2 data-[state=active]:border-black data-[state=active]:bg-transparent data-[state=active]:text-black font-black text-lg',
+              activeTab !== 'created' && 'text-gray-400 border-transparent',
+            )}
+          >
+            Created
+          </TabsPrimitive.Trigger>
+          <TabsPrimitive.Trigger
+            value="collected"
+            className={cn(
+              'flex-1 py-3 rounded-none border-b-2 data-[state=active]:border-black data-[state=active]:bg-transparent data-[state=active]:text-black font-black text-lg',
+              activeTab !== 'collected' && 'text-gray-400 border-transparent',
+            )}
+          >
+            Collected
+          </TabsPrimitive.Trigger>
+        </TabsPrimitive.List>
+      </div>
+
+      <TabsPrimitive.Content value="created" className="p-2">
+        <EmojiGrid emojis={createdEmojis} />
+      </TabsPrimitive.Content>
+
+      <TabsPrimitive.Content value="collected" className="p-2">
+        <EmojiGrid emojis={collectedEmojis} />
+      </TabsPrimitive.Content>
+    </TabsPrimitive.Root>
+  );
+};

--- a/src/components/features/profile/types.ts
+++ b/src/components/features/profile/types.ts
@@ -1,0 +1,7 @@
+export interface EmojiProps {
+  id: string;
+  image: string;
+  creator: {
+    avatar: string;
+  };
+}

--- a/src/components/features/profile/userProfile.tsx
+++ b/src/components/features/profile/userProfile.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import Image from 'next/image';
+
+interface UserProfileProps {
+  username: string;
+  walletAddress: string;
+  bio: string;
+  avatar: string;
+}
+
+export const UserProfile = ({
+  username,
+  walletAddress,
+  bio,
+  avatar,
+}: UserProfileProps) => {
+  return (
+    <div className="px-4 pt-4">
+      <div className="mb-8">
+        {/* プロフィール画像とユーザー情報 */}
+        <div className="flex mb-4">
+          <div className="relative w-24 h-24">
+            <Image
+              src={avatar || '/placeholder.svg'}
+              alt="Profile"
+              fill
+              className="rounded-full object-cover"
+            />
+          </div>
+          <div className="flex flex-1 items-center justify-between ml-4">
+            <div className="pt-3">
+              <h2 className="text-2xl font-black">{username}</h2>
+              <p className="text-[13px] text-gray-600 font-bold">
+                {walletAddress}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              className="h-9 rounded-2xl text-sm px-5 bg-gray-50 hover:bg-gray-100 border-0 text-gray-600 mt-3 font-black"
+            >
+              Edit Profile
+            </Button>
+          </div>
+        </div>
+
+        {/* Bio */}
+        <p className="text-[15px] text-gray-800 font-bold">{bio}</p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/pages/profilePage.tsx
+++ b/src/components/pages/profilePage.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { ProfileHeader } from '@/components/features/profile/profileHeader';
+import { ProfileTabs } from '@/components/features/profile/profileTabs';
+import { UserProfile } from '@/components/features/profile/userProfile';
+
+// ダミーデータ
+const USER_DATA = {
+  username: 'Jesse.eth',
+  walletAddress: '0x7849a...9ehg',
+  bio: 'Degen, work on LeapsXXXXXXXXXXXXXXXXXXXXXXXX',
+  avatar: '/placeholder.svg?height=80&width=80',
+};
+
+const CREATED_EMOJIS = Array(6)
+  .fill(null)
+  .map((_, i) => ({
+    id: String(i + 1),
+    image:
+      'https://hebbkx1anhila5yf.public.blob.vercel-storage.com/Group%208-FHRPq70yEc1h0CLeatZkOSPMsLbNFx.png',
+    creator: {
+      avatar: '/placeholder.svg?height=24&width=24',
+    },
+  }));
+
+export const ProfilePage = () => {
+  return (
+    <main className="min-h-screen bg-white flex flex-col font-nunito">
+      <ProfileHeader />
+      <UserProfile {...USER_DATA} />
+      <ProfileTabs createdEmojis={CREATED_EMOJIS} collectedEmojis={[]} />
+    </main>
+  );
+};


### PR DESCRIPTION
- プロフィール画面のコンポーネント構造を実装
  - ProfileHeader: ヘッダー部分（戻るボタンとメニュー）
  - UserProfile: ユーザープロフィール情報
  - ProfileTabs: Created/Collectedタブ
  - EmojiGrid: 絵文字グリッド表示の純粋コンポーネント化
- 関連するルーティングの設定
- モックデータの実装
- next/imageを使用した画像最適化
- コードの品質改善
  - TypeScriptの型修正
  - 不要なuse client directiveの削除
  - ボタンにtype属性を追加
  - 空要素をself-closingに修正