### PR TITLE
🔧 fix: レイアウトコンポーネントの修正

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -2,9 +2,9 @@ import { AuthRedirect } from '@/components/features/auth/authRedirect';
 
 export default function AuthLayout({
   children,
-}: Readonly<{
+}: {
   children: React.ReactNode;
-}>) {
+}) {
   return (
     <main>
       <AuthRedirect mode="auth" />

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { AuthRedirect } from '@/components/features/auth/authRedirect';
+import EthereumProviders from '@/lib/basename/EthereumProviders';
 
 export default function MainLayout({
   children,
-}: Readonly<{
+}: {
   children: React.ReactNode;
-}>) {
+}) {
   return (
     <main className="pt-14">
       <AuthRedirect mode="auth" />
-      {children}
+      <EthereumProviders>{children}</EthereumProviders>
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import '@/styles/globals.css';
 import { PrivyProvider } from '@/components/providers/privy-provider';
-import EthereumProviders from '@/lib/basename/EthereumProviders';
+
 import { Toaster } from 'sonner';
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -35,10 +35,8 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <PrivyProvider>
-          <EthereumProviders>
-            {children}
-            <Toaster />
-          </EthereumProviders>
+          {children}
+          <Toaster />
         </PrivyProvider>
       </body>
     </html>


### PR DESCRIPTION
- `src/app/layout.tsx`から`EthereumProviders`を削除し、`PrivyProvider`内で直接`children`と`Toaster`をレンダリング
- `src/app/(auth)/layout.tsx`の型定義を簡略化
- `src/app/(main)/layout.tsx`で`children`を`EthereumProviders`でラップしてレンダリング