### PR TITLE
✨ feat: UUIDを使用してファイル名を変更する機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@thirdweb-dev/react": "^4.9.4",
     "@thirdweb-dev/sdk": "^4.0.99",
     "@thirdweb-dev/storage": "^2.0.15",
+    "@types/uuid": "^10.0.0",
     "class-variance-authority": "^0.7.1",
     "cloudinary": "^2.6.0",
     "emoji-picker-react": "^4.12.2",
@@ -42,6 +43,7 @@
     "react-dom": "^19.0.0",
     "sonner": "^2.0.1",
     "thirdweb": "^5.94.0",
+    "uuid": "^11.1.0",
     "viem": "^2.26.3",
     "wagmi": "^2.15.0",
     "zod": "^3.24.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ dependencies:
   '@thirdweb-dev/storage':
     specifier: ^2.0.15
     version: 2.0.15
+  '@types/uuid':
+    specifier: ^10.0.0
+    version: 10.0.0
   class-variance-authority:
     specifier: ^0.7.1
     version: 0.7.1
@@ -89,6 +92,9 @@ dependencies:
   thirdweb:
     specifier: ^5.94.0
     version: 5.96.6(@hey-api/openapi-ts@0.66.7)(@types/react-dom@19.1.3)(@types/react@19.1.2)(ethers@5.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.8.3)(zod@3.24.3)
+  uuid:
+    specifier: ^11.1.0
+    version: 11.1.0
   viem:
     specifier: ^2.26.3
     version: 2.28.1(typescript@5.8.3)(zod@3.24.3)
@@ -7281,6 +7287,10 @@ packages:
 
   /@types/trusted-types@2.0.7:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+    dev: false
+
+  /@types/uuid@10.0.0:
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
     dev: false
 
   /@types/uuid@8.3.4:

--- a/src/components/features/create-emoji/hooks/useFileUpload.ts
+++ b/src/components/features/create-emoji/hooks/useFileUpload.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 export function useFileUpload() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -9,13 +10,20 @@ export function useFileUpload() {
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      setSelectedFile(file);
+      // ファイルの拡張子を取得
+      const extension = file.name.split('.').pop();
+      // UUIDを生成し、元の拡張子を付与
+      const newFileName = `${uuidv4()}.${extension}`;
+      // 新しいFileオブジェクトを作成
+      const renamedFile = new File([file], newFileName, { type: file.type });
+
+      setSelectedFile(renamedFile);
       // プレビューURLを生成
       const reader = new FileReader();
       reader.onloadend = () => {
         setPreview(reader.result as string);
       };
-      reader.readAsDataURL(file);
+      reader.readAsDataURL(renamedFile);
     } else {
       // ファイルが選択されていない場合はクリア
       setSelectedFile(null);


### PR DESCRIPTION
- ファイル選択時にUUIDを生成し、元の拡張子を付与した新しいFileオブジェクトを作成する機能を実装しました。
- package.jsonとpnpm-lock.yamlにuuidおよび@types/uuidを追加しました。