### PR TITLE
update: InstallSectionコンポーネントにPWA判定フックを追加し、PWAでない場合のみインストールボタンを表示するように修正

### DIFF
--- a/src/components/features/signInSignUp/InstallSection.tsx
+++ b/src/components/features/signInSignUp/InstallSection.tsx
@@ -4,14 +4,15 @@ import { SignInSignUpButton } from '@/components/features/auth/SignInSignUpButto
 import { InstallButton } from '@/components/features/signInSignUp/InstallButton';
 import { InstallModal } from '@/components/features/signInSignUp/InstallModal';
 import { useInstallPrompt } from '@/components/features/signInSignUp/hooks/useInstallPrompt';
+import { useIsPWA } from '@/lib/hooks/useIsPWA';
 
 export const InstallSection = () => {
   const { showInstallModal, setShowInstallModal, handleInstall } =
     useInstallPrompt();
-
+  const isPWA = useIsPWA();
   return (
     <div className="flex flex-col items-center gap-4">
-      <InstallButton onClick={handleInstall} />
+      {!isPWA && <InstallButton onClick={handleInstall} />}
       <SignInSignUpButton />
       <InstallModal
         open={showInstallModal}

--- a/src/lib/hooks/useIsPWA.ts
+++ b/src/lib/hooks/useIsPWA.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+type DisplayMode = 'standalone' | 'browser' | 'minimal-ui' | 'fullscreen';
+
+const getDisplayMode = (): DisplayMode | null => {
+  if (typeof window === 'undefined') return null;
+
+  const mediaQuery = window.matchMedia('(display-mode: standalone)');
+  if (mediaQuery.matches) return 'standalone';
+
+  return null;
+};
+
+const isIOSStandalone = (): boolean => {
+  if (typeof navigator === 'undefined') return false;
+
+  return (
+    'standalone' in navigator &&
+    typeof navigator.standalone === 'boolean' &&
+    navigator.standalone
+  );
+};
+
+export const useIsPWA = () => {
+  const [isPWA, setIsPWA] = useState(false);
+
+  useEffect(() => {
+    const displayMode = getDisplayMode();
+    setIsPWA(displayMode === 'standalone' || isIOSStandalone());
+  }, []);
+
+  return isPWA;
+};


### PR DESCRIPTION
This pull request introduces a new hook, `useIsPWA`, to detect if the app is running as a Progressive Web App (PWA) and updates the `InstallSection` component to conditionally render the `InstallButton` based on this detection. 

### New Feature: PWA Detection

* [`src/lib/hooks/useIsPWA.ts`](diffhunk://#diff-d68aa91dc071690a0a6a9245324e188aba7f54c87e0c0ef53fc4c4e9df4caff1R1-R33): Added a custom hook, `useIsPWA`, which uses `window.matchMedia` and `navigator.standalone` to determine if the app is running in standalone mode (PWA). It also includes logic to handle both standard and iOS-specific PWA detection.

### Component Update: Conditional Rendering

* [`src/components/features/signInSignUp/InstallSection.tsx`](diffhunk://#diff-0044c68de268f331d0a084982b2c8a88381861eee359cad9b395156d76b221b6R7-R15): Integrated the `useIsPWA` hook to conditionally render the `InstallButton`. The button is now hidden if the app is running as a PWA.