### PR TITLE
✨ 環境に応じて異なるコントラクトアドレスを使用するように、EMOJI_CONTRACT_ADDRESSの設定を変更しました。これにより、…

### DIFF
--- a/src/lib/thirdweb.ts
+++ b/src/lib/thirdweb.ts
@@ -7,7 +7,9 @@ export const CLIENT_ID = 'af87b9c2acce067efa781dc3ea43644d';
 
 // コントラクトアドレス
 export const EMOJI_CONTRACT_ADDRESS =
-  '0x7B94d514d87426A23d7B1D3E13e98DF6c79C3Fe8';
+  process.env.NODE_ENV === 'production'
+    ? '0x7B94d514d87426A23d7B1D3E13e98DF6c79C3Fe8'
+    : '0xB54E5BfFaDBF798b6f3f92920E64fd1f3f59377C';
 
 // コントラクトABI
 export const EMOJI_CONTRACT_ABI = [

--- a/src/lib/thirdweb.ts
+++ b/src/lib/thirdweb.ts
@@ -9,7 +9,7 @@ export const CLIENT_ID = 'af87b9c2acce067efa781dc3ea43644d';
 export const EMOJI_CONTRACT_ADDRESS =
   process.env.NODE_ENV === 'production'
     ? '0x7B94d514d87426A23d7B1D3E13e98DF6c79C3Fe8'
-    : '0xB54E5BfFaDBF798b6f3f92920E64fd1f3f59377C';
+    : '0x10f12BC253e4833834CeA5a5B78c6b85c96F3e9b';
 
 // コントラクトABI
 export const EMOJI_CONTRACT_ABI = [


### PR DESCRIPTION
This pull request updates the `EMOJI_CONTRACT_ADDRESS` in `src/lib/thirdweb.ts` to dynamically select the contract address based on the environment (`production` or otherwise). This change enhances flexibility and ensures the correct contract is used in different deployment environments.

Environment-based contract address selection:

* [`src/lib/thirdweb.ts`](diffhunk://#diff-08572b696c46780763923a41e12cd77c180f6737eb0555d81d59d97293ef936eL10-R12): Updated `EMOJI_CONTRACT_ADDRESS` to use `process.env.NODE_ENV` for determining the appropriate contract address based on the environment.