### PR TITLE
Feature/replace ipfs

### DIFF
--- a/src/components/features/create-emoji/CreateEmojiForm.tsx
+++ b/src/components/features/create-emoji/CreateEmojiForm.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import { CreateButton } from './components/CreateButton';
 import { FileUpload } from './components/FileUpload';
 import { useFileUpload } from './hooks/useFileUpload';
-import { useIPFS } from './hooks/useIPFS';
+import { uploadMetadataToIPFS, uploadToIPFS } from './hooks/useIPFS';
 import { useThirdwebMint } from './hooks/useThirdwebMint';
 import { useWallet } from './hooks/useWallet';
 
@@ -23,7 +23,6 @@ export function CreateEmojiForm() {
   const [loading, setLoading] = useState(false);
   const [mintResult, setMintResult] = useState<MintResult>(null);
   const { selectedWalletAddress, getSelectedWallet } = useWallet();
-  const { uploadToIPFS, ipfsToHttp, uploadMetadataToIPFS } = useIPFS();
   const { mintNFT } = useThirdwebMint();
   const { isConnected } = useCollectWallet();
 
@@ -43,18 +42,18 @@ export function CreateEmojiForm() {
 
       // Step 1: 画像をIPFSにアップロード
       const imageUrl = await uploadToIPFS(selectedFile);
-      const imageHttpUrl = ipfsToHttp(imageUrl);
-      console.log(
-        `Image upload completed.\nYou can check it at:\n${imageHttpUrl}\n${imageUrl}`,
-      );
+      console.log(`Image upload completed.\nYou can check it at:\n${imageUrl}`);
 
       // Step 2: メタデータを作成してIPFSにアップロード
-      const metadataUrl = await uploadMetadataToIPFS(
-        imageUrl,
-        selectedWalletAddress,
-      );
+      const metadata = {
+        name: '',
+        description: '',
+        image: imageUrl,
+        attributes: [{ trait_type: 'creator', value: selectedWalletAddress }],
+      };
+      const metadataUrl = await uploadMetadataToIPFS(metadata);
       console.log(`metadataUrl: ${metadataUrl}`);
-      const metadataHttpUrl = ipfsToHttp(metadataUrl);
+      const metadataHttpUrl = metadataUrl;
       console.log(
         `Metadata upload completed.\nYou can check it at:\n${metadataHttpUrl}`,
       );

--- a/src/components/features/explore/hooks/useExploreNFTs.ts
+++ b/src/components/features/explore/hooks/useExploreNFTs.ts
@@ -1,3 +1,4 @@
+import { convertIpfsToGatewayUrl } from '@/lib/ipfs-utils';
 import { EMOJI_CONTRACT_ADDRESS } from '@/lib/thirdweb';
 import { useContract, useContractRead } from '@thirdweb-dev/react';
 import { useEffect, useMemo, useState } from 'react';
@@ -23,18 +24,6 @@ const IPFS_GATEWAYS = ['https://ipfs.io/ipfs/'];
 
 // メタデータキャッシュ
 const metadataCache = new Map<string, NFTMetadata>();
-
-// IPFSのURLをゲートウェイURLに変換する関数
-const convertIpfsToGatewayUrl = async (ipfsUrl: string): Promise<string> => {
-  if (!ipfsUrl) return '';
-
-  if (ipfsUrl.startsWith('ipfs://')) {
-    const ipfsHash = ipfsUrl.replace('ipfs://', '');
-    // 最初のゲートウェイで試す
-    return `${IPFS_GATEWAYS[0]}${ipfsHash}`;
-  }
-  return ipfsUrl;
-};
 
 // メタデータを取得する関数（キャッシュ付き）
 const fetchMetadata = async (url: string): Promise<NFTMetadata> => {

--- a/src/components/features/profile/hooks/useProfileNFTs.ts
+++ b/src/components/features/profile/hooks/useProfileNFTs.ts
@@ -1,3 +1,4 @@
+import { convertIpfsToGatewayUrl } from '@/lib/ipfs-utils';
 import { EMOJI_CONTRACT_ADDRESS } from '@/lib/thirdweb';
 import { useContract, useContractRead } from '@thirdweb-dev/react';
 import { useEffect, useState } from 'react';
@@ -16,15 +17,6 @@ interface NFTMetadata {
   description?: string;
   image?: string;
   [key: string]: unknown;
-}
-
-async function convertIpfsToGatewayUrl(ipfsUrl: string): Promise<string> {
-  if (!ipfsUrl) return '';
-  if (ipfsUrl.startsWith('ipfs://')) {
-    const ipfsHash = ipfsUrl.replace('ipfs://', '');
-    return `https://ipfs.io/ipfs/${ipfsHash}`;
-  }
-  return ipfsUrl;
 }
 
 async function fetchMetadata(uri: string): Promise<NFTMetadata> {

--- a/src/lib/ipfs-utils.ts
+++ b/src/lib/ipfs-utils.ts
@@ -1,0 +1,8 @@
+export const convertIpfsToGatewayUrl = (ipfsUrl: string): string => {
+  if (!ipfsUrl) return '';
+  if (ipfsUrl.startsWith('ipfs://')) {
+    const ipfsHash = ipfsUrl.replace('ipfs://', '');
+    return `https://ipfs.io/ipfs/${ipfsHash}`;
+  }
+  return ipfsUrl;
+};

--- a/taskIPFS.md
+++ b/taskIPFS.md
@@ -1,129 +1,71 @@
-# IPFS置き換えタスク: ThirdwebからNFT.Storageへの移行
+# IPFSアップロード機能: nft.storage HTTP APIへの移行
 
 ## 概要
-EmojiChatプロジェクトでIPFS実装をThirdwebからNFT.Storageに置き換えるタスクの詳細内容。
+EmojiChatプロジェクトのIPFS/NFTストレージ機能を、nft.storageのHTTP API（APIキー認証）を用いた実装に置き換える。
 
-## 重要な注意事項
-**2024年6月30日にNFT.Storage Classicのアップロード機能が停止されました。**
-代替案として以下のサービスを検討する必要があります：
-- **Web3.Storage** (推奨)
-- **Filebase**
-- **Lighthouse Storage**
+---
 
-## 現在の実装状況
+## 1. 影響範囲
 
-### 影響を受けるファイル
-1. **`src/components/features/create-emoji/hooks/useIPFS.ts`** - メインのIPFS処理
-2. **`src/components/features/chat/chat-room/hooks/useGlobalNFTs.ts`** - IPFS URL変換
-3. **`src/components/features/explore/hooks/useExploreNFTs.ts`** - IPFS URL変換
-4. **`src/components/features/profile/hooks/useProfileNFTs.ts`** - IPFS URL変換
-5. **`src/components/features/create-emoji/CreateEmojiForm.tsx`** - useIPFS利用
-6. **`src/components/pages/CollectEmojiPage.tsx`** - IPFS関連表示
+- `src/components/features/create-emoji/hooks/useIPFS.ts`
+  - ファイル/メタデータのアップロード処理をHTTP API呼び出しに変更
+- `src/components/features/explore/hooks/useExploreNFTs.ts`
+  - IPFS URL変換処理は共通化
+- `src/components/features/profile/hooks/useProfileNFTs.ts`
+  - IPFS URL変換処理は共通化
+- `src/lib/ipfs-utils.ts`
+  - IPFS→HTTP変換関数の共通化
 
-### 現在の実装パターン
-- **Thirdweb Storage**を使用したファイルアップロード
-- **IPFS URL**から**HTTP URL**への変換
-- **メタデータ**のIPFSアップロード
+---
 
-## 推奨移行先: Web3.Storage
+## 2. 必要な環境変数
 
-### Web3.Storageの特徴
-- **料金**: 無料プラン（5GB）、有料プラン（$10/月〜）
-- **技術**: IPFS + Filecoin
-- **パフォーマンス**: 高速な読み書き
-- **互換性**: S3互換API
-
-### 必要なライブラリ
-```bash
-pnpm add web3.storage
-pnpm remove @thirdweb-dev/storage
+`.env.local`に以下を追加
+```
+NFT_STORAGE_API_KEY=your_api_key_here
 ```
 
-## 実装タスク詳細
+---
 
-### 1. 環境変数設定
-```env
-# .env.local に追加
-WEB3_STORAGE_API_TOKEN=your_api_token_here
-```
+## 3. 実装例
 
-### 2. useIPFS.tsの書き換え
+### 3.1 ファイルアップロード（HTTP API）
 
-**現在の実装**:
 ```typescript
-import { ThirdwebStorage } from '@thirdweb-dev/storage';
+export async function uploadToIPFS(file: File): Promise<string> {
+  const formData = new FormData();
+  formData.append('file', file);
 
-const storage = new ThirdwebStorage({
-  clientId: CLIENT_ID,
-});
+  const res = await fetch('https://api.nft.storage/upload', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.NFT_STORAGE_API_KEY}`,
+    },
+    body: formData,
+  });
 
-export const useIPFS = () => {
-  const uploadToIPFS = async (file: File): Promise<string> => {
-    const uri = await storage.upload(file);
-    return uri;
-  };
-  
-  const uploadMetadataToIPFS = async (imageUrl: string, creatorAddress: string) => {
-    const metadata = {
-      name: '',
-      description: '',
-      image: imageUrl,
-      attributes: [{ trait_type: 'creator', value: creatorAddress }],
-    };
-    const metadataUrl = await storage.upload(metadata);
-    return metadataUrl;
-  };
-};
-```
-
-**新しい実装**:
-```typescript
-import { Web3Storage } from 'web3.storage';
-
-const storage = new Web3Storage({ 
-  token: process.env.WEB3_STORAGE_API_TOKEN! 
-});
-
-export const useIPFS = () => {
-  const uploadToIPFS = async (file: File): Promise<string> => {
-    const cid = await storage.put([file]);
-    return `ipfs://${cid}/${file.name}`;
-  };
-  
-  const uploadMetadataToIPFS = async (imageUrl: string, creatorAddress: string) => {
-    const metadata = {
-      name: '',
-      description: '',
-      image: imageUrl,
-      attributes: [{ trait_type: 'creator', value: creatorAddress }],
-    };
-    const metadataBlob = new Blob([JSON.stringify(metadata)], { 
-      type: 'application/json' 
-    });
-    const metadataFile = new File([metadataBlob], 'metadata.json');
-    const cid = await storage.put([metadataFile]);
-    return `ipfs://${cid}/metadata.json`;
-  };
-};
-```
-
-### 3. IPFS URL変換の統一
-
-**現在の実装** (各ファイルで重複):
-```typescript
-async function convertIpfsToGatewayUrl(ipfsUrl: string): Promise<string> {
-  if (!ipfsUrl) return '';
-  if (ipfsUrl.startsWith('ipfs://')) {
-    const ipfsHash = ipfsUrl.replace('ipfs://', '');
-    return `https://ipfs.io/ipfs/${ipfsHash}`;
-  }
-  return ipfsUrl;
+  if (!res.ok) throw new Error('Upload failed');
+  const data = await res.json();
+  return `ipfs://${data.value.cid}`;
 }
 ```
 
-**新しい統一実装**:
+### 3.2 メタデータアップロード
+
 ```typescript
-// src/lib/ipfs-utils.ts (新規作成)
+export async function uploadMetadataToIPFS(metadata: object): Promise<string> {
+  const blob = new Blob([JSON.stringify(metadata)], { type: 'application/json' });
+  const file = new File([blob], 'metadata.json');
+  return await uploadToIPFS(file);
+}
+```
+
+---
+
+## 4. IPFS URL変換の共通化
+
+`src/lib/ipfs-utils.ts`にて
+```typescript
 export const convertIpfsToGatewayUrl = (ipfsUrl: string): string => {
   if (!ipfsUrl) return '';
   if (ipfsUrl.startsWith('ipfs://')) {
@@ -132,150 +74,19 @@ export const convertIpfsToGatewayUrl = (ipfsUrl: string): string => {
   }
   return ipfsUrl;
 };
-
-export const getReliableIpfsUrl = async (ipfsUrl: string): Promise<string> => {
-  const gateways = [
-    'https://ipfs.io/ipfs/',
-    'https://cloudflare-ipfs.com/ipfs/',
-    'https://gateway.pinata.cloud/ipfs/',
-  ];
-  
-  const hash = ipfsUrl.replace('ipfs://', '');
-  
-  for (const gateway of gateways) {
-    try {
-      const response = await fetch(`${gateway}${hash}`, { 
-        method: 'HEAD',
-        signal: AbortSignal.timeout(5000)
-      });
-      if (response.ok) {
-        return `${gateway}${hash}`;
-      }
-    } catch (error) {
-      continue;
-    }
-  }
-  
-  return `https://ipfs.io/ipfs/${hash}`;
-};
 ```
 
-### 4. 各ファイルの更新内容
+## 5. 注意事項
 
-#### `useGlobalNFTs.ts`
-```typescript
-import { convertIpfsToGatewayUrl } from '@/lib/ipfs-utils';
+- **APIキーを使ったnft.storageへのアップロード処理は、必ずサーバーサイド（例: Next.jsのServer ActionsやAPI Routeなど）で実行してください。クライアントサイドでAPIキーを扱う実装は絶対に避けてください。**
+- APIキーの漏洩に注意（サーバーサイドでのみ利用推奨）
+- アップロードサイズ制限やレートリミットに注意
+- 既存データの互換性は維持
 
-// convertIpfsToGatewayUrl関数を削除し、共通ライブラリを使用
-```
+---
 
-#### `useExploreNFTs.ts`
-```typescript
-import { convertIpfsToGatewayUrl, getReliableIpfsUrl } from '@/lib/ipfs-utils';
+## 6. 完了条件
 
-// 重複コードを削除し、共通ライブラリを使用
-// 複数ゲートウェイ対応を追加
-```
-
-#### `useProfileNFTs.ts`
-```typescript
-import { convertIpfsToGatewayUrl } from '@/lib/ipfs-utils';
-
-// convertIpfsToGatewayUrl関数を削除し、共通ライブラリを使用
-```
-
-### 5. 環境変数とドキュメント更新
-
-#### `README.md`更新
-```markdown
-# Web3.Storage configuration
-WEB3_STORAGE_API_TOKEN=your_api_token_here
-```
-
-#### `.env.example`作成/更新
-```env
-# Web3.Storage configuration
-WEB3_STORAGE_API_TOKEN=your_api_token_here
-```
-
-## 実装手順
-
-### Step 1: 依存関係の更新
-```bash
-pnpm add web3.storage
-pnpm remove @thirdweb-dev/storage
-```
-
-### Step 2: 環境変数設定
-1. Web3.Storageでアカウント作成
-2. APIトークン取得
-3. `.env.local`に追加
-
-### Step 3: 共通ライブラリ作成
-1. `src/lib/ipfs-utils.ts`を作成
-2. IPFS URL変換関数を統一
-
-### Step 4: useIPFS.tsの書き換え
-1. Web3.Storageライブラリに移行
-2. アップロード処理を更新
-
-### Step 5: 各ファイルの更新
-1. 重複コードを削除
-2. 共通ライブラリを使用
-3. エラーハンドリング強化
-
-### Step 6: テストと検証
-1. 絵文字作成機能のテスト
-2. 既存NFTの表示確認
-3. IPFS URL変換の動作確認
-
-## 注意事項
-
-### 1. 既存データの互換性
-- 既存のIPFS URLは変更されない
-- 新しいアップロードのみWeb3.Storageを使用
-
-### 2. エラーハンドリング
-- ネットワークエラー対応
-- APIレート制限対応
-- フォールバック機能
-
-### 3. パフォーマンス
-- 複数ゲートウェイでの冗長性
-- タイムアウト設定
-- キャッシュ機能
-
-### 4. セキュリティ
-- APIトークンの適切な管理
-- 環境変数の設定
-- エラーメッセージでの機密情報漏洩防止
-
-## 完了条件
-
-- [x] 現在の実装調査完了
-- [x] 移行先サービス選定完了
-- [ ] Web3.Storageライブラリ導入
-- [ ] useIPFS.ts書き換え完了
-- [ ] 共通ライブラリ作成完了
-- [ ] 各ファイル更新完了
-- [ ] 環境変数設定完了
-- [ ] テスト完了
-- [ ] ドキュメント更新完了
-
-## 推定作業時間
-- **実装**: 4-6時間
-- **テスト**: 2-3時間
-- **ドキュメント**: 1時間
-- **総計**: 7-10時間
-
-## 追加検討事項
-
-### 代替サービス比較
-1. **Web3.Storage**: 推奨、無料プランあり
-2. **Filebase**: より多くの無料ストレージ
-3. **継続使用**: Thirdweb Storage（現状維持）
-
-### 将来的な拡張
-- 複数ストレージプロバイダー対応
-- 自動冗長化機能
-- 使用量モニタリング
+- [x] HTTP APIによるアップロード実装
+- [x] 共通ユーティリティの整理
+- [x] ドキュメント更新

--- a/taskIPFS.md
+++ b/taskIPFS.md
@@ -1,0 +1,281 @@
+# IPFS置き換えタスク: ThirdwebからNFT.Storageへの移行
+
+## 概要
+EmojiChatプロジェクトでIPFS実装をThirdwebからNFT.Storageに置き換えるタスクの詳細内容。
+
+## 重要な注意事項
+**2024年6月30日にNFT.Storage Classicのアップロード機能が停止されました。**
+代替案として以下のサービスを検討する必要があります：
+- **Web3.Storage** (推奨)
+- **Filebase**
+- **Lighthouse Storage**
+
+## 現在の実装状況
+
+### 影響を受けるファイル
+1. **`src/components/features/create-emoji/hooks/useIPFS.ts`** - メインのIPFS処理
+2. **`src/components/features/chat/chat-room/hooks/useGlobalNFTs.ts`** - IPFS URL変換
+3. **`src/components/features/explore/hooks/useExploreNFTs.ts`** - IPFS URL変換
+4. **`src/components/features/profile/hooks/useProfileNFTs.ts`** - IPFS URL変換
+5. **`src/components/features/create-emoji/CreateEmojiForm.tsx`** - useIPFS利用
+6. **`src/components/pages/CollectEmojiPage.tsx`** - IPFS関連表示
+
+### 現在の実装パターン
+- **Thirdweb Storage**を使用したファイルアップロード
+- **IPFS URL**から**HTTP URL**への変換
+- **メタデータ**のIPFSアップロード
+
+## 推奨移行先: Web3.Storage
+
+### Web3.Storageの特徴
+- **料金**: 無料プラン（5GB）、有料プラン（$10/月〜）
+- **技術**: IPFS + Filecoin
+- **パフォーマンス**: 高速な読み書き
+- **互換性**: S3互換API
+
+### 必要なライブラリ
+```bash
+pnpm add web3.storage
+pnpm remove @thirdweb-dev/storage
+```
+
+## 実装タスク詳細
+
+### 1. 環境変数設定
+```env
+# .env.local に追加
+WEB3_STORAGE_API_TOKEN=your_api_token_here
+```
+
+### 2. useIPFS.tsの書き換え
+
+**現在の実装**:
+```typescript
+import { ThirdwebStorage } from '@thirdweb-dev/storage';
+
+const storage = new ThirdwebStorage({
+  clientId: CLIENT_ID,
+});
+
+export const useIPFS = () => {
+  const uploadToIPFS = async (file: File): Promise<string> => {
+    const uri = await storage.upload(file);
+    return uri;
+  };
+  
+  const uploadMetadataToIPFS = async (imageUrl: string, creatorAddress: string) => {
+    const metadata = {
+      name: '',
+      description: '',
+      image: imageUrl,
+      attributes: [{ trait_type: 'creator', value: creatorAddress }],
+    };
+    const metadataUrl = await storage.upload(metadata);
+    return metadataUrl;
+  };
+};
+```
+
+**新しい実装**:
+```typescript
+import { Web3Storage } from 'web3.storage';
+
+const storage = new Web3Storage({ 
+  token: process.env.WEB3_STORAGE_API_TOKEN! 
+});
+
+export const useIPFS = () => {
+  const uploadToIPFS = async (file: File): Promise<string> => {
+    const cid = await storage.put([file]);
+    return `ipfs://${cid}/${file.name}`;
+  };
+  
+  const uploadMetadataToIPFS = async (imageUrl: string, creatorAddress: string) => {
+    const metadata = {
+      name: '',
+      description: '',
+      image: imageUrl,
+      attributes: [{ trait_type: 'creator', value: creatorAddress }],
+    };
+    const metadataBlob = new Blob([JSON.stringify(metadata)], { 
+      type: 'application/json' 
+    });
+    const metadataFile = new File([metadataBlob], 'metadata.json');
+    const cid = await storage.put([metadataFile]);
+    return `ipfs://${cid}/metadata.json`;
+  };
+};
+```
+
+### 3. IPFS URL変換の統一
+
+**現在の実装** (各ファイルで重複):
+```typescript
+async function convertIpfsToGatewayUrl(ipfsUrl: string): Promise<string> {
+  if (!ipfsUrl) return '';
+  if (ipfsUrl.startsWith('ipfs://')) {
+    const ipfsHash = ipfsUrl.replace('ipfs://', '');
+    return `https://ipfs.io/ipfs/${ipfsHash}`;
+  }
+  return ipfsUrl;
+}
+```
+
+**新しい統一実装**:
+```typescript
+// src/lib/ipfs-utils.ts (新規作成)
+export const convertIpfsToGatewayUrl = (ipfsUrl: string): string => {
+  if (!ipfsUrl) return '';
+  if (ipfsUrl.startsWith('ipfs://')) {
+    const ipfsHash = ipfsUrl.replace('ipfs://', '');
+    return `https://ipfs.io/ipfs/${ipfsHash}`;
+  }
+  return ipfsUrl;
+};
+
+export const getReliableIpfsUrl = async (ipfsUrl: string): Promise<string> => {
+  const gateways = [
+    'https://ipfs.io/ipfs/',
+    'https://cloudflare-ipfs.com/ipfs/',
+    'https://gateway.pinata.cloud/ipfs/',
+  ];
+  
+  const hash = ipfsUrl.replace('ipfs://', '');
+  
+  for (const gateway of gateways) {
+    try {
+      const response = await fetch(`${gateway}${hash}`, { 
+        method: 'HEAD',
+        signal: AbortSignal.timeout(5000)
+      });
+      if (response.ok) {
+        return `${gateway}${hash}`;
+      }
+    } catch (error) {
+      continue;
+    }
+  }
+  
+  return `https://ipfs.io/ipfs/${hash}`;
+};
+```
+
+### 4. 各ファイルの更新内容
+
+#### `useGlobalNFTs.ts`
+```typescript
+import { convertIpfsToGatewayUrl } from '@/lib/ipfs-utils';
+
+// convertIpfsToGatewayUrl関数を削除し、共通ライブラリを使用
+```
+
+#### `useExploreNFTs.ts`
+```typescript
+import { convertIpfsToGatewayUrl, getReliableIpfsUrl } from '@/lib/ipfs-utils';
+
+// 重複コードを削除し、共通ライブラリを使用
+// 複数ゲートウェイ対応を追加
+```
+
+#### `useProfileNFTs.ts`
+```typescript
+import { convertIpfsToGatewayUrl } from '@/lib/ipfs-utils';
+
+// convertIpfsToGatewayUrl関数を削除し、共通ライブラリを使用
+```
+
+### 5. 環境変数とドキュメント更新
+
+#### `README.md`更新
+```markdown
+# Web3.Storage configuration
+WEB3_STORAGE_API_TOKEN=your_api_token_here
+```
+
+#### `.env.example`作成/更新
+```env
+# Web3.Storage configuration
+WEB3_STORAGE_API_TOKEN=your_api_token_here
+```
+
+## 実装手順
+
+### Step 1: 依存関係の更新
+```bash
+pnpm add web3.storage
+pnpm remove @thirdweb-dev/storage
+```
+
+### Step 2: 環境変数設定
+1. Web3.Storageでアカウント作成
+2. APIトークン取得
+3. `.env.local`に追加
+
+### Step 3: 共通ライブラリ作成
+1. `src/lib/ipfs-utils.ts`を作成
+2. IPFS URL変換関数を統一
+
+### Step 4: useIPFS.tsの書き換え
+1. Web3.Storageライブラリに移行
+2. アップロード処理を更新
+
+### Step 5: 各ファイルの更新
+1. 重複コードを削除
+2. 共通ライブラリを使用
+3. エラーハンドリング強化
+
+### Step 6: テストと検証
+1. 絵文字作成機能のテスト
+2. 既存NFTの表示確認
+3. IPFS URL変換の動作確認
+
+## 注意事項
+
+### 1. 既存データの互換性
+- 既存のIPFS URLは変更されない
+- 新しいアップロードのみWeb3.Storageを使用
+
+### 2. エラーハンドリング
+- ネットワークエラー対応
+- APIレート制限対応
+- フォールバック機能
+
+### 3. パフォーマンス
+- 複数ゲートウェイでの冗長性
+- タイムアウト設定
+- キャッシュ機能
+
+### 4. セキュリティ
+- APIトークンの適切な管理
+- 環境変数の設定
+- エラーメッセージでの機密情報漏洩防止
+
+## 完了条件
+
+- [x] 現在の実装調査完了
+- [x] 移行先サービス選定完了
+- [ ] Web3.Storageライブラリ導入
+- [ ] useIPFS.ts書き換え完了
+- [ ] 共通ライブラリ作成完了
+- [ ] 各ファイル更新完了
+- [ ] 環境変数設定完了
+- [ ] テスト完了
+- [ ] ドキュメント更新完了
+
+## 推定作業時間
+- **実装**: 4-6時間
+- **テスト**: 2-3時間
+- **ドキュメント**: 1時間
+- **総計**: 7-10時間
+
+## 追加検討事項
+
+### 代替サービス比較
+1. **Web3.Storage**: 推奨、無料プランあり
+2. **Filebase**: より多くの無料ストレージ
+3. **継続使用**: Thirdweb Storage（現状維持）
+
+### 将来的な拡張
+- 複数ストレージプロバイダー対応
+- 自動冗長化機能
+- 使用量モニタリング


### PR DESCRIPTION
This pull request refactors the IPFS integration in the EmojiChat project by transitioning to the `nft.storage` HTTP API for file and metadata uploads, centralizing IPFS URL conversion logic, and improving code maintainability. The changes include updates to the `useIPFS` hook, the creation of a shared utility for IPFS URL conversion, and documentation updates.

### IPFS Integration Refactor

**File and Metadata Uploads:**
- [`src/components/features/create-emoji/hooks/useIPFS.ts`](diffhunk://#diff-e4bbf0fc0774815a01a16a1ddc4d8ad83bb54b6b3155105373859fb0cf87d517L1-R24): Replaced the Thirdweb SDK-based IPFS upload implementation with `nft.storage` HTTP API calls using an API key. Added new functions `uploadToIPFS` and `uploadMetadataToIPFS` for handling file and metadata uploads.

**IPFS URL Conversion Logic:**
- [`src/lib/ipfs-utils.ts`](diffhunk://#diff-8530009deb36a949ba319e7f0ba25bf502216a99d86efa61629043212eab585aR1-R8): Centralized the IPFS-to-HTTP URL conversion logic in a new utility function `convertIpfsToGatewayUrl`.
- Updated `src/components/features/explore/hooks/useExploreNFTs.ts` and `src/components/features/profile/hooks/useProfileNFTs.ts` to use the shared utility for IPFS URL conversion. Removed duplicate conversion functions from these files. [[1]](diffhunk://#diff-b2cbac625edd68c7caacad2e9e334dce8386979721861cdaefe91405e03a5b4fR1) [[2]](diffhunk://#diff-a46a8272b3900b0f053892fe781659b653ac2d1e858aa2342794d7495325795bR1)

### Documentation Updates
- [`taskIPFS.md`](diffhunk://#diff-a545d195ccc65f2c2bb01e7c91b19c97aa9ac70a95e3fb3eae6d4d75e2ab05b9R1-R92): Added detailed documentation outlining the migration to `nft.storage` HTTP API, including implementation examples, environment variable requirements, and best practices for API key security.